### PR TITLE
fix: 🐛 Reset state when dependency is added

### DIFF
--- a/src/deps-are-equal.ts
+++ b/src/deps-are-equal.ts
@@ -2,11 +2,8 @@ export function depsAreEqual(
   prevDeps: React.DependencyList,
   deps: React.DependencyList
 ): boolean {
-  for (let i = 0; i < prevDeps.length; i++) {
-    if (Object.is(prevDeps[i], deps[i])) {
-      continue;
-    }
-    return false;
-  }
-  return true;
+  return (
+    prevDeps.length === deps.length &&
+    deps.every((dep, index) => Object.is(dep, prevDeps[index]))
+  );
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -77,6 +77,24 @@ describe("#use-state-with-deps", () => {
     expect(state).toBe(2);
   });
 
+  test("should reset if a new dependency is added to the end of the array", () => {
+    const { result, rerender } = renderHook<
+      { value: number; deps: any[] },
+      [number, React.Dispatch<React.SetStateAction<number>>]
+    >(
+      ({ value, deps }) => {
+        const state = useStateWithDeps(value, deps);
+        return state;
+      },
+      { initialProps: { value: 1, deps: [5, 6, 7] } }
+    );
+    let [state] = result.current;
+    expect(state).toBe(1);
+    rerender({ value: 2, deps: [5, 6, 7, 8] });
+    [state] = result.current;
+    expect(state).toBe(2);
+  });
+
   test("should call initial state function with undefined on first run", () => {
     let lastStateValue;
     const { result, rerender } = renderHook<


### PR DESCRIPTION
Previously adding an additional dependency to the dependency array did not reset the state.

Example:
```ts
const previousDeps = [1, 2]
const newDeps = [1, 2, 3]
```
now correctly resets the state.

Fixes depsAreEqual() flaw #131